### PR TITLE
fix: update BotListSpace

### DIFF
--- a/docs/general/services.md
+++ b/docs/general/services.md
@@ -54,19 +54,6 @@ Website: https://blist.xyz
 
 <div align=center>
   <p>
-    <img src="https://botlist.space/img/android-chrome-512x512.png" alt="botlistspace logo" width="100" align="left" />
-  </p>
-  <i id="botlistspace"></i>
-  <i id="botlist.space"></i>
-  <a href="https://botlist.space"><h1>botlist.space</h1></a>
-
-Keys: `botlistspace`, `botlist.space`  
-Class: [dbots.BotListSpace](/#/docs/main/$$$ref/class/BotListSpace)  
-Website: https://botlist.space
-</div>
-
-<div align=center>
-  <p>
     <img src="https://botsdatabase.com/images/icons/favicon-96x96.png" alt="botsdatabase logo" width="100" align="left" />
   </p>
   <i id="botsdatabase"></i>
@@ -233,6 +220,21 @@ Website: https://discordextremelist.xyz/
 Keys: `discordlabs`, `discordlabs.org`  
 Class: [dbots.DiscordLabs](/#/docs/main/$$$ref/class/DiscordLabs)  
 Website: https://bots.discordlabs.org/
+</div>
+
+<div align=center>
+  <p>
+    <img src="https://discordlist.space/img/android-chrome-512x512.png" alt="discordlistspace logo" width="100" align="left" />
+  </p>
+  <i id="discordlistspace"></i>
+  <i id="discordlist.space"></i>
+  <i id="botlistspace"></i>
+  <i id="botlist.space"></i>
+  <a href="https://discordlist.space"><h1>discordlist.space</h1></a>
+
+Keys: `discordlistspace`, `discordlist.space`, `botlistspace`, `botlist.space`  
+Class: [dbots.DiscordListSpace](/#/docs/main/$$$ref/class/DiscordListSpace)  
+Website: https://discordlist.space
 </div>
 
 <div align=center>

--- a/docs/general/services.md
+++ b/docs/general/services.md
@@ -224,19 +224,6 @@ Website: https://bots.discordlabs.org/
 
 <div align=center>
   <p>
-    <img src="https://discordlistology.com/idiscord.png" alt="discordlistology logo" width="100" align="left" />
-  </p>
-  <i id="discordlistology"></i>
-  <i id="discordlistology.com"></i>
-  <a href="https://discordlistology.com/"><h1>DiscordListology</h1></a>
-
-Keys: `discordlistology`, `discordlistology.com`  
-Class: [DiscordListology](/#/docs/main/$$$ref/class/DiscordListology)  
-Website: https://discordlistology.com/
-</div>
-
-<div align=center>
-  <p>
     <img src="https://discordlist.space/img/android-chrome-512x512.png" alt="discordlistspace logo" width="100" align="left" />
   </p>
   <i id="discordlistspace"></i>
@@ -248,6 +235,19 @@ Website: https://discordlistology.com/
 Keys: `discordlistspace`, `discordlist.space`, `botlistspace`, `botlist.space`  
 Class: [DiscordListSpace](/#/docs/main/$$$ref/class/DiscordListSpace)  
 Website: https://discordlist.space
+</div>
+
+<div align=center>
+  <p>
+    <img src="https://discordlistology.com/idiscord.png" alt="discordlistology logo" width="100" align="left" />
+  </p>
+  <i id="discordlistology"></i>
+  <i id="discordlistology.com"></i>
+  <a href="https://discordlistology.com/"><h1>DiscordListology</h1></a>
+
+Keys: `discordlistology`, `discordlistology.com`  
+Class: [DiscordListology](/#/docs/main/$$$ref/class/DiscordListology)  
+Website: https://discordlistology.com/
 </div>
 
 <div align=center>

--- a/src/Interface/Lists/DiscordListSpace.ts
+++ b/src/Interface/Lists/DiscordListSpace.ts
@@ -3,7 +3,7 @@ import { Util, CountResolvable, IDResolvable } from '../../Utils/Util'
 import { Query } from '../../Utils/Constants'
 
 /**
- * Represents the botlist.space service.
+ * Represents the discordlist.space service.
  * @see https://docs.botlist.space/
  */
 export default class DiscordListSpace extends Service {

--- a/src/Interface/Lists/DiscordListSpace.ts
+++ b/src/Interface/Lists/DiscordListSpace.ts
@@ -6,30 +6,35 @@ import { Query } from '../../Utils/Constants'
  * Represents the botlist.space service.
  * @see https://docs.botlist.space/
  */
-export default class BotListSpace extends Service {
+export default class DiscordListSpace extends Service {
   /** The values that can be used to select the service. */
   static get aliases() {
-    return ['botlistspace', 'botlist.space']
+    return [
+      'discordlistspace',
+      'discordlist.space',
+      'botlistspace',
+      'botlist.space'
+    ]
   }
 
   /** The logo URL. */
   static get logoURL() {
-    return 'https://botlist.space/img/android-chrome-512x512.png'
+    return 'https://discordlist.space/img/android-chrome-512x512.png'
   }
 
   /** Service's name. */
   static get serviceName() {
-    return 'botlist.space'
+    return 'discordlist.space'
   }
 
   /** The website URL. */
   static get websiteURL() {
-    return 'https://botlist.space'
+    return 'https://discordlist.space'
   }
 
   /** The base URL of the service's API. */
   static get baseURL() {
-    return 'https://api.botlist.space/v1'
+    return 'https://api.discordlist.space/v1'
   }
 
   /**


### PR DESCRIPTION
They've changed name and URL to discordlist.space.
The docs ref still uses the old domain because they haven't updated it yet.