### PR TITLE
fix(BotsForDiscord): Update API and website URLs

### DIFF
--- a/src/Interface/ListIndex.ts
+++ b/src/Interface/ListIndex.ts
@@ -39,6 +39,7 @@ export const serviceList = {
   'blist.xyz': Blist,
   'botsfordiscord': BotsForDiscord,
   'botsfordiscord.com': BotsForDiscord,
+  'discords': BotsForDiscord,
   'botsondiscord': BotsOnDiscord,
   'bots.ondiscord.xyz': BotsOnDiscord,
   'carbonitex': Carbon,

--- a/src/Interface/Lists/BotsForDiscord.ts
+++ b/src/Interface/Lists/BotsForDiscord.ts
@@ -4,12 +4,12 @@ import { Query } from '../../Utils/Constants'
 
 /**
  * Represents the Bots For Discord service.
- * @see https://docs.botsfordiscord.com/
+ * @see https://discords.com/bots/
  */
 export default class BotsForDiscord extends Service {
   /** The values that can be used to select the service. */
   static get aliases() {
-    return ['botsfordiscord', 'botsfordiscord.com']
+    return ['botsfordiscord', 'botsfordiscord.com', 'discords']
   }
 
   /** The logo URL. */
@@ -24,12 +24,12 @@ export default class BotsForDiscord extends Service {
 
   /** The website URL. */
   static get websiteURL() {
-    return 'https://botsfordiscord.com'
+    return 'https://discords.com/bots'
   }
 
   /** The base URL of the service's API. */
   static get baseURL() {
-    return 'https://botsfordiscord.com/api'
+    return 'https://discords.com/bots/api'
   }
 
   /**

--- a/src/Interface/Lists/BotsForDiscord.ts
+++ b/src/Interface/Lists/BotsForDiscord.ts
@@ -4,7 +4,7 @@ import { Query } from '../../Utils/Constants'
 
 /**
  * Represents the Bots For Discord service.
- * @see https://discords.com/bots/
+ * @see https://docs.botsfordiscord.com/
  */
 export default class BotsForDiscord extends Service {
   /** The values that can be used to select the service. */


### PR DESCRIPTION
BotsForDiscord has merged with [discords.com](https://discords.com/), pushing the whole website to [discords.com/bots](https://discords.com/bots/).
The former API URL work for GET requests, but POST requests are seen as GET requests i'm assuming due to bad redirecting. Regardless this updates the API URL and this works when posting server count stats.